### PR TITLE
Fix bug where duplicate registers are added

### DIFF
--- a/src/dslite_parser.rs
+++ b/src/dslite_parser.rs
@@ -74,6 +74,7 @@ pub fn parse_dslite(file_name: &Path) -> Device {
                     let mut reg = r.clone();
                     reg.alternate = Some(old.name.clone());
                     modules.get_mut(&r.module).unwrap().registers.push(reg);
+                    continue;
                 } else {
                     modules
                         .entry(r.module.clone())


### PR DESCRIPTION
There was a bug where generated SVD files had duplicate registers only for registers that aliases an used memory location. This PR fixes it so that running svd2rust on the SVD output for msp430fr2355 produces buildable code without modifications.