### PR TITLE
Update Dependencies (except `svd-parser`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,19 +2,19 @@
 # It is not intended for manual editing.
 [[package]]
 name = "Inflector"
-version = "0.11.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.4"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -24,35 +24,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lazy_static"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libc"
-version = "0.2.37"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.0.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "msp430gen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "Inflector 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "svd-parser 0.5.1",
- "xmltree 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xmltree 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -62,19 +49,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "0.2.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.4.2"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -86,30 +72,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.5"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"
@@ -121,11 +88,8 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.4.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "xmltree"
@@ -137,28 +101,23 @@ dependencies = [
 
 [[package]]
 name = "xmltree"
-version = "0.4.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "xml-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum Inflector 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e16d701dbf2baf8c117fc5cc84280e665793ede1b3814230b800bf52f4e73bb"
-"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+"checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)" = "56aebce561378d99a0bb578f8cb15b6114d2a1814a6c7949bbe646d968bb4fa9"
-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum ordermap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88fc9d511a8e8d3adc7ba9f4b8f9683a2eface9c14b652ad77f975c4f95c787b"
-"checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
-"checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+"checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec6c39eaa68382c8e31e35239402c0a9489d4141a8ceb0c716099a0b515b562"
-"checksum xml-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b46ee689ba7a669c08a1170c2348d2516c62dc461135c9e86b2f1f476e07be4a"
+"checksum xml-rs 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2bb76e5c421bbbeb8924c60c030331b345555024d56261dae8f3e786ed817c23"
+"checksum xmltree 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77a607efe600db25447a8d9bab1f39217a82c4ba160b51b027d7c4f6053004df"
 "checksum xmltree 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "472a9d37c7c53ab2391161df5b89b1f3bf76dab6ab150d7941ecbdd832282082"
-"checksum xmltree 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "973f1a8be3ef2ce1388e0821093ce67d5eb4c2e897e88866e2ed6dd7a63920ed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,9 +18,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "indexmap"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -37,15 +50,10 @@ name = "msp430gen"
 version = "0.2.0"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "svd-parser 0.5.1",
  "xmltree 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "ordermap"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
@@ -110,10 +118,11 @@ dependencies = [
 [metadata]
 "checksum Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-"checksum ordermap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88fc9d511a8e8d3adc7ba9f4b8f9683a2eface9c14b652ad77f975c4f95c787b"
 "checksum regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "msp430gen"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Vadzim Dambrouski <pftbest@gmail.com>"]
 
 [dependencies]
 #ldscript-parser = "0.1"
-xmltree = "*"
+xmltree = "0.10.0"
 svd-parser = { path = "svd-parser" }
 ordermap = "=0.4.0"
 Inflector = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Vadzim Dambrouski <pftbest@gmail.com>"]
 #ldscript-parser = "0.1"
 xmltree = "0.10.0"
 svd-parser = { path = "svd-parser" }
-ordermap = "=0.4.0"
+indexmap = "1.3.2"
 Inflector = "0.11.1"

--- a/src/dslite_parser.rs
+++ b/src/dslite_parser.rs
@@ -1,7 +1,7 @@
 use ordermap::OrderMap;
 use std::path::Path;
 use utils;
-use xmltree::Element;
+use xmltree::{XMLNode, Element};
 
 #[derive(Debug)]
 pub struct Device {
@@ -25,11 +25,12 @@ pub fn parse_dslite(file_name: &Path) -> Device {
 
     let name = uw!(el.attributes.get("id")).to_owned();
     let description = uw!(el.attributes.get("description")).to_owned();
-    let cpu = uw!(el.children.iter().find(|i| i.name == "cpu"));
+    let cpu = uw!(el.children.iter().find(|i| i.as_element().map_or(false, |e| e.name == "cpu")));
 
     let mut cached_modules = OrderMap::new();
     let mut registers = Vec::new();
-    for i in &cpu.children {
+
+    for i in &cpu.as_element().expect("The node named CPU wasn't an XML Element!").children {
         if let Some(mut module) = parse_cpu_instance(i, file_name) {
             // Remove all registers from the module before we cache it, since we will fill in the
             // registers after we process duplicates. This two-step caching process also prevents
@@ -112,7 +113,8 @@ pub struct Module {
     pub registers: Vec<Register>,
 }
 
-fn parse_cpu_instance(el: &Element, root_file: &Path) -> Option<Module> {
+fn parse_cpu_instance(node: &XMLNode, root_file: &Path) -> Option<Module> {
+    let el = node.as_element().expect("CPU instance was not an XML Element!");
     assert_eq!(el.name, "instance");
     let base = uw!(utils::parse_u32(uw!(el.attributes.get("baseaddr"))));
 
@@ -137,7 +139,7 @@ fn parse_dslite_module(file_name: &Path, baseaddr: u32) -> Option<Module> {
     let mut registers = el
         .children
         .iter()
-        .map(|r| parse_register(r, &name))
+        .map(|r| parse_register(r.as_element().expect("Register was not an XML Element!"), &name))
         .collect::<Vec<_>>();
 
     // Rest of the code assumes that the offset value of each register includes the base address of
@@ -186,7 +188,7 @@ fn parse_register(el: &Element, module: &str) -> Register {
     let fields = el
         .children
         .iter()
-        .map(|f| parse_field(f))
+        .map(|f| parse_field(f.as_element().expect("Field was not an XML Element!")))
         .collect::<Vec<_>>();
 
     Register {
@@ -245,7 +247,7 @@ fn parse_field(el: &Element) -> Field {
     let enums = el
         .children
         .iter()
-        .map(|e| parse_enum(e))
+        .map(|e| parse_enum(e.as_element().expect("Enums was not an XML Element!")))
         .collect::<Vec<_>>();
 
     Field {

--- a/src/dslite_parser.rs
+++ b/src/dslite_parser.rs
@@ -1,4 +1,4 @@
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 use std::path::Path;
 use utils;
 use xmltree::{XMLNode, Element};
@@ -7,10 +7,10 @@ use xmltree::{XMLNode, Element};
 pub struct Device {
     pub name: String,
     pub description: String,
-    pub modules: OrderMap<String, Module>,
+    pub modules: IndexMap<String, Module>,
 }
 
-fn get_conflict<'a>(map: &OrderMap<u32, &'a Register>, reg: &Register) -> Option<&'a Register> {
+fn get_conflict<'a>(map: &IndexMap<u32, &'a Register>, reg: &Register) -> Option<&'a Register> {
     for i in 0..reg.width {
         let addr = reg.offset + i;
         if let Some(old) = map.get(&addr) {
@@ -27,7 +27,7 @@ pub fn parse_dslite(file_name: &Path) -> Device {
     let description = uw!(el.attributes.get("description")).to_owned();
     let cpu = uw!(el.children.iter().find(|i| i.as_element().map_or(false, |e| e.name == "cpu")));
 
-    let mut cached_modules = OrderMap::new();
+    let mut cached_modules = IndexMap::new();
     let mut registers = Vec::new();
 
     for i in &cpu.as_element().expect("The node named CPU wasn't an XML Element!").children {
@@ -53,8 +53,8 @@ pub fn parse_dslite(file_name: &Path) -> Device {
         }
     });
 
-    let mut modules: OrderMap<String, Module> = OrderMap::new();
-    let mut memory: OrderMap<u32, &Register> = OrderMap::new();
+    let mut modules: IndexMap<String, Module> = IndexMap::new();
+    let mut memory: IndexMap<u32, &Register> = IndexMap::new();
     for r in &registers {
         if let Some(old) = get_conflict(&memory, r) {
             if r.width == 2 && old.width == 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 extern crate inflector;
-extern crate ordermap;
+extern crate indexmap;
 extern crate svd_parser as svd;
 extern crate xmltree;
 

--- a/src/svd_writer.rs
+++ b/src/svd_writer.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use svd::*;
-use xmltree::Element;
+use xmltree::{Element, XMLNode};
 
 fn write_string(name: &str, text: &str) -> Element {
     let mut el = Element::new(name);
-    el.text = Some(String::from(text));
+    el.children = vec![];
+    el.children.push(XMLNode::Text(String::from(text)));
     el
 }
 
@@ -31,22 +32,22 @@ fn write_access(a: &Access) -> Element {
 pub fn write_device(dev: &Device) -> String {
     let mut el = Element::new("device");
     el.children = vec![];
-    el.children.push(write_string("name", &dev.name));
+    el.children.push(XMLNode::Element(write_string("name", &dev.name)));
 
     if let Some(x) = dev.defaults.size {
-        el.children.push(write_string("size", &x.to_string()));
+        el.children.push(XMLNode::Element(write_string("size", &x.to_string())));
     }
     if let Some(x) = dev.defaults.reset_value {
-        el.children.push(write_string("resetValue", &x.to_string()));
+        el.children.push(XMLNode::Element(write_string("resetValue", &x.to_string())));
     }
     if let Some(x) = dev.defaults.reset_mask {
-        el.children.push(write_string("resetMask", &x.to_string()));
+        el.children.push(XMLNode::Element(write_string("resetMask", &x.to_string())));
     }
     if let Some(x) = dev.defaults.access {
-        el.children.push(write_access(&x));
+        el.children.push(XMLNode::Element(write_access(&x)));
     }
 
-    el.children.push(write_peripherals(dev));
+    el.children.push(XMLNode::Element(write_peripherals(dev)));
 
     let mut out = Vec::new();
     el.write(&mut out);
@@ -58,7 +59,7 @@ fn write_peripherals(dev: &Device) -> Element {
     el.children = vec![];
 
     for p in &dev.peripherals {
-        el.children.push(write_peripheral(p));
+        el.children.push(XMLNode::Element(write_peripheral(p)));
     }
     el
 }
@@ -67,18 +68,18 @@ fn write_peripheral(per: &Peripheral) -> Element {
     let mut el = Element::new("peripheral");
     el.children = vec![];
 
-    el.children.push(write_string("name", &per.name));
+    el.children.push(XMLNode::Element(write_string("name", &per.name)));
 
     if let Some(x) = per.group_name.as_ref() {
-        el.children.push(write_string("groupName", x));
+        el.children.push(XMLNode::Element(write_string("groupName", x)));
     }
 
     if let Some(x) = per.description.as_ref() {
-        el.children.push(write_string("description", x));
+        el.children.push(XMLNode::Element(write_string("description", x)));
     }
 
     el.children
-        .push(write_string("baseAddress", &per.base_address.to_string()));
+        .push(XMLNode::Element(write_string("baseAddress", &per.base_address.to_string())));
 
     if let Some(x) = per.derived_from.as_ref() {
         el.attributes = HashMap::new();
@@ -86,11 +87,11 @@ fn write_peripheral(per: &Peripheral) -> Element {
     }
 
     if let Some(x) = per.registers.as_ref() {
-        el.children.push(write_registers(x))
+        el.children.push(XMLNode::Element(write_registers(x)))
     }
 
     for int in &per.interrupt {
-        el.children.push(write_interrupt(int))
+        el.children.push(XMLNode::Element(write_interrupt(int)))
     }
 
     el
@@ -100,14 +101,14 @@ fn write_interrupt(int: &Interrupt) -> Element {
     let mut el = Element::new("interrupt");
     el.children = vec![];
 
-    el.children.push(write_string("name", &int.name));
+    el.children.push(XMLNode::Element(write_string("name", &int.name)));
 
     if let Some(x) = int.description.as_ref() {
-        el.children.push(write_string("description", x));
+        el.children.push(XMLNode::Element(write_string("description", x)));
     }
 
     el.children
-        .push(write_string("value", &int.value.to_string()));
+        .push(XMLNode::Element(write_string("value", &int.value.to_string())));
 
     el
 }
@@ -117,7 +118,7 @@ fn write_registers(per: &[Register]) -> Element {
     el.children = vec![];
 
     for r in per {
-        el.children.push(write_register(r));
+        el.children.push(XMLNode::Element(write_register(r)));
     }
     el
 }
@@ -131,41 +132,41 @@ fn write_register(reg: &Register) -> Element {
         _ => panic!("arrays are not supported"),
     };
 
-    el.children.push(write_string("name", &reg.name));
+    el.children.push(XMLNode::Element(write_string("name", &reg.name)));
     el.children
-        .push(write_string("description", &reg.description));
-    el.children.push(write_string(
+        .push(XMLNode::Element(write_string("description", &reg.description)));
+    el.children.push(XMLNode::Element(write_string(
         "addressOffset",
         &reg.address_offset.to_string(),
-    ));
+    )));
 
     if let Some(x) = reg.size {
-        el.children.push(write_string("size", &x.to_string()));
+        el.children.push(XMLNode::Element(write_string("size", &x.to_string())));
     }
 
     if let Some(x) = reg.access {
-        el.children.push(write_access(&x));
+        el.children.push(XMLNode::Element(write_access(&x)));
     }
 
     if let Some(x) = reg.reset_value {
-        el.children.push(write_string("resetValue", &x.to_string()));
+        el.children.push(XMLNode::Element(write_string("resetValue", &x.to_string())));
     }
 
     if let Some(x) = reg.reset_mask {
-        el.children.push(write_string("resetMask", &x.to_string()));
+        el.children.push(XMLNode::Element(write_string("resetMask", &x.to_string())));
     }
 
     if let Some(x) = reg.fields.as_ref() {
-        el.children.push(write_fields(x))
+        el.children.push(XMLNode::Element(write_fields(x)))
     }
 
     if let Some(wc) = reg.write_constraint.as_ref() {
-        el.children.push(write_constraint(wc))
+        el.children.push(XMLNode::Element(write_constraint(wc)))
     }
 
     if let Some(x) = reg.alternate_register.as_ref() {
         el.children
-            .push(write_string("alternateRegister", &x.to_string()));
+            .push(XMLNode::Element(write_string("alternateRegister", &x.to_string())));
     }
 
     el
@@ -176,7 +177,7 @@ fn write_fields(per: &[Field]) -> Element {
     el.children = vec![];
 
     for r in per {
-        el.children.push(write_field(r));
+        el.children.push(XMLNode::Element(write_field(r)));
     }
     el
 }
@@ -185,27 +186,27 @@ fn write_field(reg: &Field) -> Element {
     let mut el = Element::new("field");
     el.children = vec![];
 
-    el.children.push(write_string("name", &reg.name));
+    el.children.push(XMLNode::Element(write_string("name", &reg.name)));
 
     if let Some(x) = reg.description.as_ref() {
-        el.children.push(write_string("description", x));
+        el.children.push(XMLNode::Element(write_string("description", x)));
     }
 
     el.children
-        .push(write_string("bitOffset", &reg.bit_range.offset.to_string()));
+        .push(XMLNode::Element(write_string("bitOffset", &reg.bit_range.offset.to_string())));
     el.children
-        .push(write_string("bitWidth", &reg.bit_range.width.to_string()));
+        .push(XMLNode::Element(write_string("bitWidth", &reg.bit_range.width.to_string())));
 
     if let Some(x) = reg.access {
-        el.children.push(write_access(&x));
+        el.children.push(XMLNode::Element(write_access(&x)));
     }
 
     for e in &reg.enumerated_values {
-        el.children.push(write_enums(e))
+        el.children.push(XMLNode::Element(write_enums(e)))
     }
 
     if let Some(wc) = reg.write_constraint.as_ref() {
-        el.children.push(write_constraint(wc))
+        el.children.push(XMLNode::Element(write_constraint(wc)))
     }
 
     el
@@ -219,14 +220,17 @@ fn write_constraint(wc: &WriteConstraint) -> Element {
         WriteConstraint::Range(r) => {
             let mut min_el = Element::new("minimum");
             let mut max_el = Element::new("maximum");
-            min_el.text = Some(r.min.to_string());
-            max_el.text = Some(r.max.to_string());
-            range_el.children.push(min_el);
-            range_el.children.push(max_el);
+            min_el.children = vec![];
+            max_el.children = vec![];
+
+            min_el.children.push(XMLNode::Text(r.min.to_string()));
+            max_el.children.push(XMLNode::Text(r.max.to_string()));
+            range_el.children.push(XMLNode::Element(min_el));
+            range_el.children.push(XMLNode::Element(max_el));
         }
         _ => panic!("unsupported write constraint"),
     }
-    wc_el.children.push(range_el);
+    wc_el.children.push(XMLNode::Element(range_el));
     wc_el
 }
 
@@ -235,11 +239,11 @@ fn write_enums(per: &EnumeratedValues) -> Element {
     el.children = vec![];
 
     if let Some(x) = per.name.as_ref() {
-        el.children.push(write_string("name", x));
+        el.children.push(XMLNode::Element(write_string("name", x)));
     }
 
     if let Some(x) = per.usage.as_ref() {
-        el.children.push(write_usage(x));
+        el.children.push(XMLNode::Element(write_usage(x)));
     }
 
     if let Some(x) = per.derived_from.as_ref() {
@@ -248,7 +252,7 @@ fn write_enums(per: &EnumeratedValues) -> Element {
     }
 
     for e in &per.values {
-        el.children.push(write_enum_val(e));
+        el.children.push(XMLNode::Element(write_enum_val(e)));
     }
 
     el
@@ -258,18 +262,18 @@ fn write_enum_val(reg: &EnumeratedValue) -> Element {
     let mut el = Element::new("enumeratedValue");
     el.children = vec![];
 
-    el.children.push(write_string("name", &reg.name));
+    el.children.push(XMLNode::Element(write_string("name", &reg.name)));
 
     if let Some(x) = reg.description.as_ref() {
-        el.children.push(write_string("description", x));
+        el.children.push(XMLNode::Element(write_string("description", x)));
     }
 
     if let Some(x) = reg.value {
-        el.children.push(write_string("value", &x.to_string()));
+        el.children.push(XMLNode::Element(write_string("value", &x.to_string())));
     }
 
     if let Some(x) = reg.is_default {
-        el.children.push(write_string("isDefault", &x.to_string()));
+        el.children.push(XMLNode::Element(write_string("isDefault", &x.to_string())));
     }
 
     el


### PR DESCRIPTION
I've confirmed the output for `msp430g2211` and `msp430f5529` is identical compared to before these changes.

Removing our outdated copy of `svd-parser` is blocked on [deriving more traits](https://github.com/rust-embedded/svd/issues/111).