### PR TITLE
Overrides for the MSP430FR4133

### DIFF
--- a/overrides/devices/msp430fr4133.yaml
+++ b/overrides/devices/msp430fr4133.yaml
@@ -1,0 +1,6 @@
+_svd: ../../msp430fr4133.svd
+
+_include:
+  - "../peripherals/fram.yaml"
+  - "../peripherals/pmmctl.yaml"
+  - "../peripherals/watchdog_timer.yaml"

--- a/overrides/peripherals/fram.yaml
+++ b/overrides/peripherals/fram.yaml
@@ -1,0 +1,14 @@
+FRAM:
+  FRCTL0:
+    _add:
+      FRCTLPW:
+        description: FRCTLPW Password
+        bitOffset: 8
+        bitWidth: 8
+    FRCTLPW:
+      _read:
+        PASSWORD: [0x96, "Value always reads from the FRCTL0 register"]
+      _write:
+        PASSWORD: [0xA5, "Value which must be written to the FRCTL0 register"]
+
+

--- a/overrides/peripherals/pmmctl.yaml
+++ b/overrides/peripherals/pmmctl.yaml
@@ -1,0 +1,35 @@
+PMM:
+  PMMCTL0:
+    _add:
+      PMMPW:
+        description: PMM Password
+        bitOffset: 8
+        bitWidth: 8
+        access: read-write
+    PMMPW:
+      _read:
+        PASSWORD: [0x96, "Values always reads from the PMMCTL0 register"]
+      _write:
+        PASSWORD: [0xA5, "Values which must be written to the PMMCTL0 register"]
+  PMMCTL2:
+    _add:
+      REFGEN:
+        description: Reference generator trigger. If written with a 1, the generation of the variable reference voltage is started. When the reference voltage request is set, this bit is cleared by hardware or writing 0.
+        bitOffset: 6
+        bitWidth: 1
+        access: read-write
+      REFBGEN:
+        description: Bandgap and bandgap buffer trigger. If written with a 1, the generation of the buffered bandgap voltage is started. When the bandgap buffer voltage request is set, this bit is cleared by hardware or writing 0.
+        bitOffset: 7
+        bitWidth: 1
+        access: read-write
+      REFVSEL:
+        description: Internal reference voltage level select. 00b = 1.5V, 01b = 2.0V, 10b = 2.5V
+        bitOffset: 4
+        bitWidth: 2
+        access: read-write
+    REFVSEL:
+            REFVSEL_0: [0, "00b = 1.5V"]
+            REFVSEL_1: [1, "01b = 2.0V"]
+            REFVSEL_2: [2, "10b = 2.5V"]
+            REFVSEL_3: [3, "11b = Reserved"]


### PR DESCRIPTION
This adds some missing registers and missing parts of registers for the MPS430FR4133 such as the `PMMCTLPW` and `FRCTLPW` which were missing.

I've gone over the "family user guide": http://www.ti.com/lit/ug/slau445i/slau445i.pdf and I'm not 100% confident this is everything that is missing from the originally generated SVD unfortunately.