### PR TITLE
Remove command creating bkup file and just specify output

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to use msp430g2553 as an example):
 The output of the above command will be written to `msp430g2211.svd.patched`
 (hardcoded). You can format the patched portions by running `xmllint`:
 
-    $ xmllint -format msp430g2553.svd.patched --output msp430g2553.svd.patched
+    $ xmllint --format msp430g2553.svd.patched --output msp430g2553.svd.patched
 
 At this point, you may wish to compare the original _formatted_ output to the
 patched output to double-check the results:

--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ to use msp430g2553 as an example):
 The output of the above command will be written to `msp430g2211.svd.patched`
 (hardcoded). You can format the patched portions by running `xmllint`:
 
-    $ mv msp430g2553.svd.patched msp430g2553.svd.patched.bak
-      xmllint -format msp430g2553.svd.patched.bak > msp430g2553.svd.patched
+    $ xmllint -format msp430g2553.svd.patched --output msp430g2553.svd.patched
 
 At this point, you may wish to compare the original _formatted_ output to the
 patched output to double-check the results:


### PR DESCRIPTION
I was just following through the commands in the README.md and got to the section I modified. I skipped making the `*.bkup` file and then had a moment of confusion when `xmllint` choked on the empty file. Since the purpose of the bkup file seems to just have a temporary place to store the data instead of out of concern of losing the file I just specified the `--output` command.

It's a trivial change, but might save some people a minute or two (or longer if they're not used to bash conventions).