### PR TITLE
Add MSP430FR247x patches

### DIFF
--- a/overrides/devices/msp430fr2475.yaml
+++ b/overrides/devices/msp430fr2475.yaml
@@ -1,0 +1,26 @@
+_svd: ../../msp430fr2475.svd
+
+_include:
+  - "../peripherals/usci_a0_spi_ucbusy.yaml"
+  - "../peripherals/usci_a1_spi_ucbusy.yaml"
+  - "../peripherals/usci_b0_spi_ucbusy.yaml"
+  - "../peripherals/usci_b1_spi_ucbusy.yaml"
+  - "../peripherals/pmmctl_pmmpw_enum.yaml"
+
+SYS:
+  SYSSNIV:
+    SYSSNIV:
+      _replace_enum:
+        NONE: [0, "No interrupt pending"]
+        SVSLIFG: [2, "SVS low-power reset entry"]
+        UBDIFG: [4, "Uncorrectable FRAM bit error detection"]
+        ACCTEIFG: [6, "FRAM Access Time Error"]
+        SYSSNIV_8: [8, "Reserved"]
+        SYSSNIV_10: [10, "Reserved"]
+        SYSSNIV_12: [12, "Reserved"]
+        SYSSNIV_14: [14, "Reserved"]
+        SYSSNIV_16: [16, "Reserved"]
+        VMAIFG: [18, "VMAIFG Vacant memory access"]
+        JMBINIFG: [20, "JMBINIFG JTAG mailbox input"]
+        JMBOUTIFG: [22, "JMBOUTIFG JTAG mailbox output"]
+        CBDIFG: [24, "Correctable FRAM bit error detection"]

--- a/overrides/devices/msp430fr2475.yaml
+++ b/overrides/devices/msp430fr2475.yaml
@@ -24,3 +24,59 @@ SYS:
         JMBINIFG: [20, "JMBINIFG JTAG mailbox input"]
         JMBOUTIFG: [22, "JMBOUTIFG JTAG mailbox output"]
         CBDIFG: [24, "Correctable FRAM bit error detection"]
+
+"_INTERRUPTS":
+  _modify:
+    _interrupts:
+      ECOMP0:
+          value: 37
+      PORT6:
+          value: 38
+      PORT5:
+          value: 39
+      PORT4:
+          value: 40
+      PORT3:
+          value: 41
+      PORT2:
+          value: 42
+      PORT1:
+          value: 43
+      ADC:
+          value: 44
+      EUSCI_B1:
+          value: 45
+      EUSCI_B0:
+          value: 46
+      EUSCI_A1:
+          value: 47
+      EUSCI_A0:
+          value: 48
+      WDT:
+          value: 49
+      RTC:
+          value: 50
+      TIMER0_B1:
+          value: 51
+      TIMER0_B0:
+          value: 52
+      TIMER3_A1:
+          value: 53
+      TIMER3_A0:
+          value: 54
+      TIMER2_A1:
+          value: 55
+      TIMER2_A0:
+          value: 56
+      TIMER1_A1:
+          value: 57
+      TIMER1_A0:
+          value: 58
+      TIMER0_A1:
+          value: 59
+      TIMER0_A0:
+          value: 60
+      UNMI:
+          value: 61
+      SYSNMI:
+          value: 62

--- a/overrides/devices/msp430fr2476.yaml
+++ b/overrides/devices/msp430fr2476.yaml
@@ -1,0 +1,26 @@
+_svd: ../../msp430fr2476.svd
+
+_include:
+  - "../peripherals/usci_a0_spi_ucbusy.yaml"
+  - "../peripherals/usci_a1_spi_ucbusy.yaml"
+  - "../peripherals/usci_b0_spi_ucbusy.yaml"
+  - "../peripherals/usci_b1_spi_ucbusy.yaml"
+  - "../peripherals/pmmctl_pmmpw_enum.yaml"
+
+SYS:
+  SYSSNIV:
+    SYSSNIV:
+      _replace_enum:
+        NONE: [0, "No interrupt pending"]
+        SVSLIFG: [2, "SVS low-power reset entry"]
+        UBDIFG: [4, "Uncorrectable FRAM bit error detection"]
+        ACCTEIFG: [6, "FRAM Access Time Error"]
+        SYSSNIV_8: [8, "Reserved"]
+        SYSSNIV_10: [10, "Reserved"]
+        SYSSNIV_12: [12, "Reserved"]
+        SYSSNIV_14: [14, "Reserved"]
+        SYSSNIV_16: [16, "Reserved"]
+        VMAIFG: [18, "VMAIFG Vacant memory access"]
+        JMBINIFG: [20, "JMBINIFG JTAG mailbox input"]
+        JMBOUTIFG: [22, "JMBOUTIFG JTAG mailbox output"]
+        CBDIFG: [24, "Correctable FRAM bit error detection"]

--- a/overrides/devices/msp430fr2476.yaml
+++ b/overrides/devices/msp430fr2476.yaml
@@ -24,3 +24,59 @@ SYS:
         JMBINIFG: [20, "JMBINIFG JTAG mailbox input"]
         JMBOUTIFG: [22, "JMBOUTIFG JTAG mailbox output"]
         CBDIFG: [24, "Correctable FRAM bit error detection"]
+
+"_INTERRUPTS":
+  _modify:
+    _interrupts:
+      ECOMP0:
+          value: 37
+      PORT6:
+          value: 38
+      PORT5:
+          value: 39
+      PORT4:
+          value: 40
+      PORT3:
+          value: 41
+      PORT2:
+          value: 42
+      PORT1:
+          value: 43
+      ADC:
+          value: 44
+      EUSCI_B1:
+          value: 45
+      EUSCI_B0:
+          value: 46
+      EUSCI_A1:
+          value: 47
+      EUSCI_A0:
+          value: 48
+      WDT:
+          value: 49
+      RTC:
+          value: 50
+      TIMER0_B1:
+          value: 51
+      TIMER0_B0:
+          value: 52
+      TIMER3_A1:
+          value: 53
+      TIMER3_A0:
+          value: 54
+      TIMER2_A1:
+          value: 55
+      TIMER2_A0:
+          value: 56
+      TIMER1_A1:
+          value: 57
+      TIMER1_A0:
+          value: 58
+      TIMER0_A1:
+          value: 59
+      TIMER0_A0:
+          value: 60
+      UNMI:
+          value: 61
+      SYSNMI:
+          value: 62


### PR DESCRIPTION
- Renamed reserved SYSSNIV entries to SYSSNIV_8, SYSSNIV_10, etc. to avoid generic 'None' names
  (following style from [SYS_445.xml](https://github.com/pftbest/msp430_svd/blob/master/msp430-gcc-support-files/targetdb/Modules/msp430/SYS_445.xml) in msp430_svd)
- Added missing UCBUSY bit in eUSCI registers